### PR TITLE
fix for conflict detection with windows paths

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -2,10 +2,10 @@ var fs = require('fs');
 var path = require('path');
 
 var dirname = __dirname.replace(/\\/g, '/');
-var root = dirname.slice(0, dirname.lastIndexOf('/node_modules/'));
+var root = path.resolve(dirname.slice(0, dirname.lastIndexOf('/node_modules/')));
 var link = root + '/node_modules/~';
 try {
-  var existingReal = fs.realpathSync(link);
+  var existingReal = path.resolve(fs.realpathSync(link));
 } catch (e) {
   fs.symlinkSync(root, link, 'junction');
   process.exit(0);


### PR DESCRIPTION
On windows, these functions can return paths with backslashes or forward slashes, so they need to be standardized via the path module.

This fixes an issue that was preventing `npm rebuild` from completing, for me, unless I removed the ~ directory first. It's possible that it might fix other windows issues as well.